### PR TITLE
Handle loose dlls that were extracted.

### DIFF
--- a/scripts/download_unzip_install_mods.sh
+++ b/scripts/download_unzip_install_mods.sh
@@ -210,6 +210,10 @@ move_extracted_files() {
     mkdir -p $plugins_mod_dir
     mkdir -p $user_mod_dir
 
+    # Copy any extracted loose dll files, move them to BepInEx/plugins.
+    cp $tmp_extracted_dir/*.dll $plugins_mod_dir 2> /dev/null
+    rm $tmp_extracted_dir/*.dll 2> /dev/null
+
     # Copy the BepInEx directory to where it needs to go. Some mods have the p in plugins capitalized
     cp -rf $tmp_extracted_dir/BepInEx/plugins/* $plugins_mod_dir 2> /dev/null
     cp -rf $tmp_extracted_dir/BepInEx/Plugins/* $plugins_mod_dir 2> /dev/null
@@ -231,7 +235,7 @@ move_extracted_files() {
 }
 
 move_remaining_downloaded_files() {
-    # If there are any loose dll files, move them to BepInEx/plugins.
+    # Copy any downloaded loose dll files, move them to BepInEx/plugins.
     cp $tmp_downloaded_dir/*.dll $plugins_mod_dir 2> /dev/null
     rm $tmp_downloaded_dir/*.dll 2> /dev/null
 }


### PR DESCRIPTION
This handles the case of a loose .dll being extracted from a compressed file (ie at the root of the compressed file and not in the `BepInEx/plugins` structure). The download mods script already handled when a loose .dll was downloaded directly but not when a loose .dll is compressed first.