### PR TITLE
Add time zone support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ That's it! The image has everything else you need to run an SPT Server, with Fik
     * [What it does](#what-it-does)
     * [How to use it](#how-to-use-it)
     * [Mod updates](#mod-updates)
+  * [Time Zone Support](#time-zone)
 - [🌐 Environment Variables](#-environment-variables)
 - [💬 FAQ](#-faq)
   * [Why are there files owned by root in my server files?](#why-are-there-files-owned-by-root-in-my-server-files)
@@ -213,6 +214,23 @@ A few other notes
 ### Mod updates
 When a mod is updated, you will need to add the new URL using one of the methods above. It will be downloaded, extracted, and then merged, overwriting any conflicting files in the installation. For simple mods that is probably enough. If the mod developer states that you will need to uninstall a previous version to update, you will have to do this manually. You may do that at any time if you want to be extra cautious.
 
+## Time Zone
+By default the container uses the UTC time zone. This does not affect running the server or the files themselves but it does affect things that like the SPT Backup Service, which sets the backup folder name to the current timestamp.
+
+If you want to change the time zone there are two methods (DO NOT USE BOTH)
+- Mount `/etc/timezone` as a volume
+- Set the `TZ` environment variable
+
+### Mount `/etc/timezone` as a volume
+This will match the time zone inside to the time zone of the host system.
+- If using docker-compose, add `/etc/timezone:/etc/timezone:ro` under the volumes section.
+- If using docker run, add `-v /etc/timezone:/etc/timezone:ro \` to the run command
+
+### Set the `TZ` environment variable
+This should be set to a TZ Identifier (see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones for a list of valid TZ identifier).
+- If using docker-compose, add `TZ=US/Eastern` under the `environment` section, substituting `US/Eastern` for your desired time zone.
+- If using docker run, add `-e TZ=US/Eastern \` to the run command
+
 # 🌐 Environment Variables
 None of these env vars are required, but they may be useful.
 | Env var                   | Default | Description |
@@ -229,6 +247,7 @@ None of these env vars are required, but they may be useful.
 | `CHANGE_PERMISSIONS`      | true    | If this is set to false, the container will not change file permissions of the server files. Make sure the running user has permissions to access these files |
 | `ENABLE_PROFILE_BACKUP`   | true    | If this is set to false, the cron job that handles profile backups will not be enabled |
 | `LISTEN_ALL_NETWORKS`     | false   | If you want to automatically set the SPT server IP addresses to allow it to listen on all network interfaces |
+| `TZ`                      | null    | Set the desired time zone. See the `Timezone` section above for details |
 
 
 # 💬 FAQ

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,10 @@ services:
       - ENABLE_PROFILE_BACKUPS=true
       # If you don't want to automatically change the SPT server IPs to allow it to listen on all interfaces, set this to false.
       - LISTEN_ALL_NETWORKS=true
+      # If you want to override the timezone. See https://en.wikipedia.org/wiki/List_of_tz_database_time_zones for a list of valid TZ codes
+      # - TZ=US/Eastern
     volumes:
       # Set this to the directory on your host containing either your existing SPT server files or where you wish to store a new SPT server install
       - ./server:/opt/server
+      # If you want to match the host system timezone
+      # - /etc/timezone:/etc/timezone:ro

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -97,6 +97,28 @@ set_permissions() {
     fi
 }
 
+set_timezone() {
+    # If the TZ environment variable has been set, use it
+    if [[ ! -z "${TZ}" ]]; then
+        # Update the /etc/timezone to the specified time zone
+        echo $TZ > /etc/timezone
+    else
+        # Grab the hour from the date command to compare against later
+        before_date_hour=$(date +"%H")
+
+        # Set TZ to the /etc/timezone, either mounted or the default from the container
+        TZ=$(cat /etc/timezone)
+    fi
+
+    # Force update the symlink
+    ln -sf /usr/share/zoneinfo/$TZ /etc/localtime
+
+    # If there was actually a change in the timezone or TZ was specified (accounted for here when before_date_hour is not set above)
+    if [[ $before_date_hour != $(date +"%H") ]]; then
+        echo "Timezone set to $TZ";
+    fi
+}
+
 ########
 # Fika #
 ########
@@ -234,5 +256,7 @@ create_running_user
 # Own mounted files as running user
 change_owner
 set_permissions
+
+set_timezone
 
 su - $(id -nu $uid) -c "cd $mounted_dir && ./SPT.Server.exe"


### PR DESCRIPTION
# Why
The SPT Backup Service and any similar mods (like the [Lua AutoProfileBackup](https://hub.sp-tarkov.com/files/file/1143-lua-s-auto-profile-backup-updated/) mod I'm currently working on updating to 3.10) create files & folders that are named using a timestamp.

When `SPT.Server.exe` is run on Windows, those timestamps are in the local system time zone. In this container it is always in UTC time. I don't live in the UTC time zone so when I would go in to restore a backup I'd need to do some head math to figure out which backup I want.

I realize this is a bit nit-picky but by default it should make no difference to a user that doesn't make any changes.

# Implementation Explained
I think how I've implemented this is a little convoluted, so I'd like to explain.

There's 3 places where a time zone could be found/set
- The `TZ` environment variable. Not set by default.
- `/etc/timezone`: this is just a txt file, that is updated in any number of ways. Set to `Etc/UTC` by default
- `/etc/localtime`: a symlink to a specific zone in `/usr/share/zoneinfo/`. Symlinked to `/usr/share/zoneinfo/Etc/UTC` by default

## Testing
I used the `date` command as a sort of baseline testing method as well as a custom .ts script that I'd just run using node (I figured it was pretty similar to how SPT runs) to ensure that the change was doing anything. Of note, my host system is running Debian 12.

- Setting the `TZ` environment variable affects the `date` command and the node script but does not affect the SPT server.
- Just mounting `/etc/timezone` from the host system does not affect the `date` command nor the SPT server.
- Just mounting `/etc/localtime` from the host system affects the `date` command and the node script but does not affect the SPT server.
- Mounting both `/etc/timezone` and `/etc/localtime` from the host system affects the `date` command and the node script but also does not affect SPT.

sgtlaggy/sptlaggy in the discord recommended resetting the `/etc/localtime` to another time zone. This is what finally worked. Of note, `/etc/localtime` is also a symlink on my host system. My theory is that SPT needs `/etc/localtime` to be a symlink to a time zone in the local `/usr/share/zoneinfo` (ie inside the container).

## Logging
I've tried to send a log message, `Timezone set to $TZ`, if and only if there was actually a change. The `before_date_hour` is my rough attempt at this. It only being set in the `else` clause (when `TZ` is not set) serves two purposes:
- There will always be a log message when the user sets `TZ`
- Only prints when the before and after timezone are different, ie when `/etc/timezone` is mounted and different than the UTC. The caveat is that in this case when `/etc/timezone` is mounted, it will only print the log message the first time the container is booted as the `date` command is affected by the symlink that is created as well.

## Side notes
### Using both methods
If someone were to do both methods, setting `TZ` and mounting `/etc/timezone` from the host, assuming they actually followed the instructions and mounted the `/etc/timezone` as read-only, then there would be a `Read-only file system` error at boot and the container would stop or continually restart.

### `dpkg-reconfigure tzdata`
In my research I found a lot of references to `dpkg-reconfigure tzdata` (or it's non-interactive flag version `dpkg-reconfigure -f noninteractive tzdata`). I went back and forth on if I was going to call it or not.

It write to both `/etc/timezone` and `/etc/localtime`, so running when either were mounted as read-only would cause a `Read-only file system` error (and stop the container from booting). I could have just run it in the case when `TZ` is specified, but it needs to be run after the symlink is updated so I would have duplicated that code. However, in my testing it was unnecessary to run the command; just setting the `/etc/localtime` symlink was enough for SPT.

#### Updating `/etc/timezone`
I'm not sure that updating the `/etc/timezone` is necessary, but I figured it was a good idea to keep it in sync, especially since `dpkg-reconfigure tzdata` also does so.
