### PR TITLE
3.11 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /
 RUN git clone https://github.com/sp-tarkov/server.git spt
 
 # SPT Server git tag or sha
-ARG SPT_SERVER_SHA=3.10.5
+ARG SPT_SERVER_SHA=3.11.0
 ARG BUILD_TYPE=release
 
 WORKDIR /spt/project
@@ -49,7 +49,7 @@ RUN apt update && apt install -y --no-install-recommends \
 
 WORKDIR /opt/server
 
-ARG SPT_SERVER_SHA=3.10.5
+ARG SPT_SERVER_SHA=3.11.0
 ARG FIKA_VERSION=v2.3.6
 ENV SPT_VERSION=$SPT_SERVER_SHA
 ENV FIKA_VERSION=$FIKA_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN apt update && apt install -y --no-install-recommends \
 WORKDIR /opt/server
 
 ARG SPT_SERVER_SHA=3.11.0
-ARG FIKA_VERSION=v2.3.6
+ARG FIKA_VERSION=v2.4.0
 ENV SPT_VERSION=$SPT_SERVER_SHA
 ENV FIKA_VERSION=$FIKA_VERSION
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM debian:bookworm AS build
 
-# SPT Server git tag or sha
-ARG SPT_SERVER_SHA=3.10.5
-
 USER root
 RUN apt update && apt install -y --no-install-recommends \
     curl \
@@ -19,6 +16,10 @@ RUN ASDF_DIR=$HOME/.asdf/ \. "$HOME/.asdf/asdf.sh" \
 WORKDIR /
 RUN git clone https://github.com/sp-tarkov/server.git spt
 
+# SPT Server git tag or sha
+ARG SPT_SERVER_SHA=3.10.5
+ARG BUILD_TYPE=release
+
 WORKDIR /spt/project
 RUN git checkout $SPT_SERVER_SHA
 RUN git lfs pull
@@ -28,7 +29,7 @@ ENV PATH="$PATH:/root/.asdf/shims"
 RUN asdf global nodejs 20.11.1
 
 RUN npm install
-RUN npm run build:release
+RUN npm run build:$BUILD_TYPE
 
 RUN mv build /opt/build
 RUN rm -rf /spt

--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ None of these env vars are required, but they may be useful.
 | `ENABLE_PROFILE_BACKUP`   | true    | If this is set to false, the cron job that handles profile backups will not be enabled |
 | `LISTEN_ALL_NETWORKS`     | false   | If you want to automatically set the SPT server IP addresses to allow it to listen on all network interfaces |
 | `TZ`                      | null    | Set the desired time zone. See the `Timezone` section above for details |
+| `NUM_HEADLESS_PROFILES`   | null    | Set the desired number of headless profiles for the Fika server to auto-generate. This must be an integer. This will only work if the `fika.jsonc` config file exists, the server automatically generates one on startup if it is missing |
 
 
 # 💬 FAQ

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ None of these env vars are required, but they may be useful.
 | `INSTALL_FIKA`            | false   | Whether you want the container to automatically install/update fika servermod for you |
 | `INSTALL_OTHER_MODS`      | false   | Whether you want the container to automatically download & install any other mods as specified  |
 | `MOD_URLS_TO_DOWNLOAD`    | null    | A space separated list of URLs you want the server to automatically download and place. Requires `INSTALL_OTHER_MODS` to be true |
-| `FIKA_VERSION`            | v2.3.6  | Override the fika version string to grab the server release from. The release URL is formatted as `https://github.com/project-fika/Fika-Server/releases/download/$FIKA_VERSION/fika-server.zip` |
+| `FIKA_VERSION`            | v2.4.0  | Override the fika version string to grab the server release from. The release URL is formatted as `https://github.com/project-fika/Fika-Server/releases/download/$FIKA_VERSION/fika-server.zip` |
 | `AUTO_UPDATE_SPT`         | false   | Whether you want the container to handle updating SPT in your existing serverfiles |
 | `AUTO_UPDATE_FIKA`        | false   | Whether you want the container to handle updating Fika server mod in your existing serverfiles |
 | `TAKE_OWNERSHIP`          | true    | If this is set to false, the container will not change file ownership of the server files. Make sure the running user has permissions to access these files |
@@ -291,7 +291,7 @@ The URL will look like `https://github.com/project-fika/Fika-Server/releases/dow
 
 ```bash
 # Server binary built using SPT Server 3.11.0 git tag, image tagged as fika-spt-server:latest
-# Downloads and validates Fika version v2.3.6
+# Downloads and validates Fika version v2.4.0
 
-VERSION=latest FIKA_VERSION=v2.3.6 SPT_SHA=3.11.0 ./build
+VERSION=latest FIKA_VERSION=v2.4.0 SPT_SHA=3.11.0 ./build
 ```

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ That's it! The image has everything else you need to run an SPT Server, with Fik
 
 
 # 🪄 Features
-- 📦 Prepackaged images versioned by SPT version e.g. `fika-spt-server-docker:3.10.5` for SPT `3.10.5`. Images are hosted in ghcr and come prebuilt with a working SPT server binary, and the latest compatible Fika servermod is downloaded and installed on container startup if enabled.
+- 📦 Prepackaged images versioned by SPT version e.g. `fika-spt-server-docker:3.11.0` for SPT `3.11.0`. Images are hosted in ghcr and come prebuilt with a working SPT server binary, and the latest compatible Fika servermod is downloaded and installed on container startup if enabled.
 - ♻️ Reuse an existing installation of SPT! Just mount your existing SPT server folder
 - 💾 Automatic profile backups by default! Profiles are copied to a backup folder every day at 00:00 UTC
 - 🔒 Configurable running user and ownership of server files. Control file ownership from the host, or let the container set ownership and permissions to ease permissions issues.
@@ -45,7 +45,7 @@ That's it! The image has everything else you need to run an SPT Server, with Fik
 # 🥡 Releases
 The image build is triggered off release tags and hosted on ghcr
 ```
-docker pull ghcr.io/zhliau/fika-spt-server-docker:3.10.5
+docker pull ghcr.io/zhliau/fika-spt-server-docker:3.11.0
 ```
 Check the pane on the right for the different version tags available, if you don't want to use the latest SPT release.
 
@@ -57,7 +57,7 @@ docker run --name fika-server \
   -e LISTEN_ALL_NETWORKS=true \
   -v /path/to/server/files:/opt/server \
   -p 6969:6969 \
-  ghcr.io/zhliau/fika-spt-server-docker:3.10.5
+  ghcr.io/zhliau/fika-spt-server-docker:3.11.0
 ```
 
 ### docker-compose
@@ -148,7 +148,7 @@ The container will validate your Fika server mod version matches the image's exp
 > If you've made any changes to files within `SPT_Data`, make backups! This upgrade process will remove that folder!
 
 A new image will be tagged with the new SPT version number, and thus you will need to
-- Update the image version tag e.g. `fika-spt-server-docker:3.9.8` to `fika-spt-server-docker:3.10.5`
+- Update the image version tag e.g. `fika-spt-server-docker:3.9.8` to `fika-spt-server-docker:3.11.0`
 - Pull the new image with `docker pull` or `docker-compose pull`
 - Bring up the container again with `docker run` or `docker-compose up`
 
@@ -281,16 +281,17 @@ This will change the values of `ip` and `backendIp` in `SPT_Data/Server/configs/
 # 💻 Development
 ### Building
 You can overwrite the expected SPT version by setting the `SPT_SHA` build arg. This must correspond with a git ref (tag or branch) in the
-SPT Server github repo. This version must be a release [semver](https://semver.org/) value, and thus pre-release refs like `3.10.5-dev` will not work.
-This is because the value is checked against the `sptVersion` value in `SPT_Data/Server/configs/core.json` when validating the SPT version on container boot.
+SPT Server github repo. This version must be a release [semver](https://semver.org/) value, or a pre-release ref like `3.11.0-dev`
+The value is checked against the `sptVersion` value in `SPT_Data/Server/configs/core.json` when validating the SPT version on container boot. If using a pre-release version tag,
+everything including and after the `-` is dropped when comparing version strings.
 
 You can similarly override the Fika version by setting the `FIKA_VERSION` build arg. Make sure this matches the Fika version slug in the Fika Server download URL.
 
 The URL will look like `https://github.com/project-fika/Fika-Server/releases/download/<FIKA_VERSION_SLUG>/fika-server.zip`
 
 ```bash
-# Server binary built using SPT Server 3.10.5 git tag, image tagged as fika-spt-server:latest
+# Server binary built using SPT Server 3.11.0 git tag, image tagged as fika-spt-server:latest
 # Downloads and validates Fika version v2.3.6
 
-VERSION=latest FIKA_VERSION=v2.3.6 SPT_SHA=3.10.5 ./build
+VERSION=latest FIKA_VERSION=v2.3.6 SPT_SHA=3.11.0 ./build
 ```

--- a/build
+++ b/build
@@ -3,5 +3,10 @@
 version_tag=${VERSION:-latest}
 spt_sha=${SPT_SHA:-3.10.5}
 fika_version=${FIKA_VERSION:-v2.3.6}
+build_type=${BUILD_TYPE:-release}
 
-docker build . --build-arg SPT_SERVER_SHA=$spt_sha --build-arg FIKA_VERSION=$fika_version -t fika-spt-server-docker:$version_tag $@
+docker build . \
+    --build-arg BUILD_TYPE=$build_type \
+    --build-arg SPT_SERVER_SHA=$spt_sha \
+    --build-arg FIKA_VERSION=$fika_version \
+    -t fika-spt-server-docker:$version_tag $@

--- a/build
+++ b/build
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 version_tag=${VERSION:-latest}
-spt_sha=${SPT_SHA:-3.10.5}
+spt_sha=${SPT_SHA:-3.11.0}
 fika_version=${FIKA_VERSION:-v2.3.6}
 build_type=${BUILD_TYPE:-release}
 

--- a/build
+++ b/build
@@ -2,7 +2,7 @@
 
 version_tag=${VERSION:-latest}
 spt_sha=${SPT_SHA:-3.11.0}
-fika_version=${FIKA_VERSION:-v2.3.6}
+fika_version=${FIKA_VERSION:-v2.4.0}
 build_type=${BUILD_TYPE:-release}
 
 docker build . \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   fika-server:
-    image: fika-spt-server-docker:3.11
+    image: ghcr.io/zhliau/fika-spt-server-docker:latest
     ports:
       - 6969:6969
     environment:
@@ -9,17 +9,17 @@ services:
       - GID=1000
       # If you want to auto-install Fika on an existing Fika-less SPT Server install, set this to true.
       # Will do nothing if your serverfiles mount already has a fika-server dir in user/mods/
-      - INSTALL_FIKA=false
+      - INSTALL_FIKA=true
       # If you want the container to update SPT automatically if it detects the SPT server version does not match expected version, set this to true
-      - AUTO_UPDATE_SPT=false
+      - AUTO_UPDATE_SPT=true
       # If you want the container to update Fika automatically if it detects the Fika server version does not match expected version, set this to true
-      - AUTO_UPDATE_FIKA=false
+      - AUTO_UPDATE_FIKA=true
       # If you don't want the container to change the file ownership of your server files, set this to false
       - TAKE_OWNERSHIP=true
       # If you don't want to automatically back up profiles, set this to false
-      - ENABLE_PROFILE_BACKUPS=false
+      - ENABLE_PROFILE_BACKUPS=true
       # If you don't want to automatically change the SPT server IPs to allow it to listen on all interfaces, set this to false.
-      - LISTEN_ALL_NETWORKS=false
+      - LISTEN_ALL_NETWORKS=true
       # If you want to override the timezone. See https://en.wikipedia.org/wiki/List_of_tz_database_time_zones for a list of valid TZ codes
       # - TZ=US/Eastern
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   fika-server:
-    image: ghcr.io/zhliau/fika-spt-server-docker:latest
+    image: fika-spt-server-docker:3.11
     ports:
       - 6969:6969
     environment:
@@ -9,17 +9,17 @@ services:
       - GID=1000
       # If you want to auto-install Fika on an existing Fika-less SPT Server install, set this to true.
       # Will do nothing if your serverfiles mount already has a fika-server dir in user/mods/
-      - INSTALL_FIKA=true
+      - INSTALL_FIKA=false
       # If you want the container to update SPT automatically if it detects the SPT server version does not match expected version, set this to true
-      - AUTO_UPDATE_SPT=true
+      - AUTO_UPDATE_SPT=false
       # If you want the container to update Fika automatically if it detects the Fika server version does not match expected version, set this to true
-      - AUTO_UPDATE_FIKA=true
+      - AUTO_UPDATE_FIKA=false
       # If you don't want the container to change the file ownership of your server files, set this to false
       - TAKE_OWNERSHIP=true
       # If you don't want to automatically back up profiles, set this to false
-      - ENABLE_PROFILE_BACKUPS=true
+      - ENABLE_PROFILE_BACKUPS=false
       # If you don't want to automatically change the SPT server IPs to allow it to listen on all interfaces, set this to false.
-      - LISTEN_ALL_NETWORKS=true
+      - LISTEN_ALL_NETWORKS=false
       # If you want to override the timezone. See https://en.wikipedia.org/wiki/List_of_tz_database_time_zones for a list of valid TZ codes
       # - TZ=US/Eastern
     volumes:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,7 +16,7 @@ spt_data_dir=$mounted_dir/SPT_Data
 spt_core_config=$spt_data_dir/Server/configs/core.json
 enable_spt_listen_on_all_networks=${LISTEN_ALL_NETWORKS:-false}
 
-fika_version=${FIKA_VERSION:-v2.3.6}
+fika_version=${FIKA_VERSION:-v2.4.0}
 install_fika=${INSTALL_FIKA:-false}
 fika_backup_dir=$backup_dir/fika/$(date +%Y%m%dT%H%M)
 fika_config_path=assets/configs/fika.jsonc

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,6 @@ backup_dir_name=${BACKUP_DIR:-backups}
 backup_dir=$mounted_dir/$backup_dir_name
 
 spt_version=${SPT_VERSION:-3.10.5}
-# Support semver with suffixes for tags e.g. 3.11.0-BE-20250219
 spt_version=$(echo $spt_version | cut -d '-' -f 1)
 spt_backup_dir=$backup_dir/spt/$(date +%Y%m%dT%H%M)
 spt_data_dir=$mounted_dir/SPT_Data

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,6 +31,8 @@ take_ownership=${TAKE_OWNERSHIP:-true}
 change_permissions=${CHANGE_PERMISSIONS:-true}
 enable_profile_backup=${ENABLE_PROFILE_BACKUP:-true}
 
+num_headless_profiles=${NUM_HEADLESS_PROFILES:+"$NUM_HEADLESS_PROFILES"}
+
 install_other_mods=${INSTALL_OTHER_MODS:-false}
 
 start_crond() {
@@ -48,6 +50,11 @@ create_running_user() {
 }
 
 validate() {
+     if [[ ${num_headless_profiles:+1} && ! $num_headless_profiles =~ ^[0-9]+$ ]]; then
+         echo "NUM_HEADLESS_PROFILES must be a number.";
+         exit 1
+     fi
+
     # Must mount /opt/server directory, otherwise the serverfiles are in container and there's no persistence
     if [[ ! $(mount | grep $mounted_dir) ]]; then
         echo "Please mount a volume/directory from the host to $mounted_dir. This server container must store files on the host."
@@ -155,6 +162,13 @@ try_update_fika() {
     echo "Successfully updated Fika from $1 to $fika_version"
 }
 
+set_num_headless_profiles() {
+    if [[ ${num_headless_profiles:+1} && -f $fika_mod_dir/$fika_config_path ]]; then
+        echo "Setting number of headless profiles to $num_headless_profiles"
+        modified_fika_jsonc="$(jq --arg jq_num_headless_profiles $num_headless_profiles '.headless.profiles.amount=$jq_num_headless_profiles' $fika_mod_dir/$fika_config_path)" && echo -E "${modified_fika_jsonc}" > $fika_mod_dir/$fika_config_path
+    fi
+}
+
 #######
 # SPT #
 #######
@@ -199,6 +213,17 @@ try_update_spt() {
     exit 0
 }
 
+spt_listen_on_all_networks() {
+    # Changes the ip and backendIp to 0.0.0.0 so that the server will listen on all network interfaces.
+    http_json=$mounted_dir/SPT_Data/Server/configs/http.json
+    modified_http_json="$(jq '.ip = "0.0.0.0" | .backendIp = "0.0.0.0"' $http_json)" && echo -E "${modified_http_json}" > $http_json
+    # If fika server config exists, modify that too
+    if [[ -f "$fika_mod_dir/$fika_config_path" ]]; then
+        echo "Setting listen all networks in Fika SPT config override"
+        modified_fika_jsonc="$(jq '.server.SPT.http.ip = "0.0.0.0" | .server.SPT.http.backendIp = "0.0.0.0"' $fika_mod_dir/$fika_config_path)" && echo -E "${modified_fika_jsonc}" > $fika_mod_dir/$fika_config_path
+    fi
+}
+
 ##############
 # Other Mods #
 ##############
@@ -212,12 +237,6 @@ install_requested_mods() {
 ##############
 # Run it All #
 ##############
-
-spt_listen_on_all_networks() {
-    # Changes the ip and backendIp to 0.0.0.0 so that the server will listen on all network interfaces.
-    http_json=$mounted_dir/SPT_Data/Server/configs/http.json
-    modified_http_json="$(jq '.ip = "0.0.0.0" | .backendIp = "0.0.0.0"' $http_json)" && echo -E "${modified_http_json}" > $http_json
-}
 
 validate
 
@@ -243,6 +262,8 @@ if [[ "$install_fika" == "true" ]]; then
         echo "Fika install requested but Fika server mod dir already exists, skipping Fika installation"
     fi
 fi
+
+set_num_headless_profiles
 
 if [[ "$install_other_mods" == "true" ]]; then
     install_requested_mods

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,8 @@ backup_dir_name=${BACKUP_DIR:-backups}
 backup_dir=$mounted_dir/$backup_dir_name
 
 spt_version=${SPT_VERSION:-3.10.5}
+# Support semver with suffixes for tags e.g. 3.11.0-BE-20250219
+spt_version=$(echo $spt_version | cut -d '-' -f 1)
 spt_backup_dir=$backup_dir/spt/$(date +%Y%m%dT%H%M)
 spt_data_dir=$mounted_dir/SPT_Data
 spt_core_config=$spt_data_dir/Server/configs/core.json


### PR DESCRIPTION
Also adds ability to specify number of headless profiles for Fika server to generate via `NUM_HEADLESS_PROFILES` env var. (fixes https://github.com/zhliau/fika-spt-server-docker/issues/15)