### PR TITLE
Expose port in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN apt update && apt install -y --no-install-recommends \
 WORKDIR /opt/server
 
 ARG SPT_SERVER_SHA=3.11.3
-ARG FIKA_VERSION=v2.4.4
+ARG FIKA_VERSION=v2.4.5
 ENV SPT_VERSION=$SPT_SERVER_SHA
 ENV FIKA_VERSION=$FIKA_VERSION
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,4 +58,7 @@ COPY entrypoint.sh /usr/bin/entrypoint
 COPY scripts/backup.sh /usr/bin/backup
 COPY scripts/download_unzip_install_mods.sh /usr/bin/download_unzip_install_mods
 COPY data/cron/cron_backup_spt /etc/cron.d/cron_backup_spt
+
+# Docker desktop doesn't allow you to configure port mappings unless this is present
+EXPOSE 6969
 ENTRYPOINT ["/usr/bin/entrypoint"]

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ None of these env vars are required, but they may be useful.
 | `INSTALL_FIKA`            | false   | Whether you want the container to automatically install/update fika servermod for you |
 | `INSTALL_OTHER_MODS`      | false   | Whether you want the container to automatically download & install any other mods as specified  |
 | `MOD_URLS_TO_DOWNLOAD`    | null    | A space separated list of URLs you want the server to automatically download and place. Requires `INSTALL_OTHER_MODS` to be true |
-| `FIKA_VERSION`            | v2.4.4  | Override the fika version string to grab the server release from. The release URL is formatted as `https://github.com/project-fika/Fika-Server/releases/download/$FIKA_VERSION/fika-server-$FIKA_VERSION.zip` |
+| `FIKA_VERSION`            | v2.4.5  | Override the fika version string to grab the server release from. The release URL is formatted as `https://github.com/project-fika/Fika-Server/releases/download/$FIKA_VERSION/fika-server-$FIKA_VERSION.zip` |
 | `AUTO_UPDATE_SPT`         | false   | Whether you want the container to handle updating SPT in your existing serverfiles |
 | `AUTO_UPDATE_FIKA`        | false   | Whether you want the container to handle updating Fika server mod in your existing serverfiles |
 | `TAKE_OWNERSHIP`          | true    | If this is set to false, the container will not change file ownership of the server files. Make sure the running user has permissions to access these files |
@@ -293,7 +293,7 @@ The URL will look like `https://github.com/project-fika/Fika-Server/releases/dow
 
 ```bash
 # Server binary built using SPT Server 3.11.3 git tag, image tagged as fika-spt-server:latest
-# Downloads and validates Fika version v2.4.4
+# Downloads and validates Fika version v2.4.5
 
-VERSION=latest FIKA_VERSION=v2.4.4 SPT_SHA=3.11.3 ./build
+VERSION=latest FIKA_VERSION=v2.4.5 SPT_SHA=3.11.3 ./build
 ```

--- a/build
+++ b/build
@@ -2,7 +2,7 @@
 
 version_tag=${VERSION:-latest}
 spt_sha=${SPT_SHA:-3.11.3}
-fika_version=${FIKA_VERSION:-v2.4.4}
+fika_version=${FIKA_VERSION:-v2.4.5}
 build_type=${BUILD_TYPE:-release}
 
 docker build . \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,7 +16,7 @@ spt_data_dir=$mounted_dir/SPT_Data
 spt_core_config=$spt_data_dir/Server/configs/core.json
 enable_spt_listen_on_all_networks=${LISTEN_ALL_NETWORKS:-false}
 
-fika_version=${FIKA_VERSION:-v2.4.4}
+fika_version=${FIKA_VERSION:-v2.4.5}
 install_fika=${INSTALL_FIKA:-false}
 fika_backup_dir=$backup_dir/fika/$(date +%Y%m%dT%H%M)
 fika_config_path=assets/configs/fika.jsonc


### PR DESCRIPTION
This is required because Docker Desktop will not reveal the option to port map if this is not available