### PR TITLE
Fixed image field in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   fika-server:
     #image: ghcr.io/zhliau/fika-spt-server-docker:latest
-    image: fika-spt-server-docker:4.0.0
+    image: ghcr.io/zhliau/fika-spt-server-docker:4.0.0
     ports:
       - 6969:6969
     environment:


### PR DESCRIPTION
compose was still using the pre-ghcr container conventions and pull failed with error. Updated to the new image shown in docs. Pull was successful after implementing the fix locally.
```
❯ docker compose up -d
[+] Running 1/1
 ✘ spt Error pull access denied for fika-spt-server-docker, repository does not exist or may require 'docker log...            1.1s 
Error response from daemon: pull access denied for fika-spt-server-docker, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
```