### PR TITLE
fix: harden entrypoint, backups, compose, and healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,11 @@ RUN apt update && apt install -y --no-install-recommends \
     ca-certificates \
     unzip \
     7zip \
-    vim \
     cron \
     exiftool \
     jq \
-    dos2unix
+    dos2unix \
+    && rm -rf /var/lib/apt/lists/*
 
 ARG SPT_VERSION=4.0.13-40087-2891fd4
 ARG FIKA_VERSION=2.3.2
@@ -18,7 +18,7 @@ ENV SPT_VERSION=$SPT_VERSION
 ENV FIKA_VERSION=$FIKA_VERSION
 
 WORKDIR /opt/build
-RUN curl -sL "https://spt-releases.modd.in/SPT-${SPT_VERSION}.7z" -o spt.7z
+RUN curl -fSL "https://spt-releases.modd.in/SPT-${SPT_VERSION}.7z" -o spt.7z
 RUN 7zz x spt.7z
 
 COPY entrypoint.sh /usr/bin/entrypoint
@@ -30,4 +30,6 @@ RUN dos2unix /usr/bin/entrypoint /usr/bin/backup /usr/bin/download_unzip_install
 
 # Docker desktop doesn't allow you to configure port mappings unless this is present
 EXPOSE 6969
+HEALTHCHECK --interval=30s --timeout=5s --start-period=180s --retries=3 \
+  CMD curl -fk https://127.0.0.1:6969/launcher/server/version || exit 1
 ENTRYPOINT ["/usr/bin/entrypoint"]

--- a/Dockerfile.multiarch
+++ b/Dockerfile.multiarch
@@ -104,7 +104,6 @@ RUN apt update && apt install -y --no-install-recommends \
     ca-certificates \
     unzip \
     7zip \
-    vim \
     cron \
     exiftool \
     jq \
@@ -137,4 +136,6 @@ RUN dos2unix /usr/bin/entrypoint /usr/bin/backup /usr/bin/download_unzip_install
 
 # Docker desktop doesn't allow you to configure port mappings unless this is present
 EXPOSE 6969
+HEALTHCHECK --interval=30s --timeout=5s --start-period=180s --retries=3 \
+  CMD curl -fk https://127.0.0.1:6969/launcher/server/version || exit 1
 ENTRYPOINT ["/usr/bin/entrypoint"]

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Minimal usage
 services:
   fika-server:
     image: ghcr.io/zhliau/fika-spt-server-docker:latest
+    restart: unless-stopped
     environment:
       - FIKA_MODE=install
       # This will automatically set SPT server's configs to work in a containerized environment
@@ -272,7 +273,7 @@ None of these env vars are required, but they may be useful.
 | ~~`AUTO_UPDATE_FIKA`~~    | false   | **DEPRECATED:** Use `FIKA_MODE=auto-update` instead                                                                                                                                                                                       |
 | `TAKE_OWNERSHIP`          | true    | If this is set to false, the container will not change file ownership of the server files. Make sure the running user has permissions to access these files                                                                               |
 | `CHANGE_PERMISSIONS`      | true    | If this is set to false, the container will not change file permissions of the server files. Make sure the running user has permissions to access these files                                                                             |
-| `ENABLE_PROFILE_BACKUP`   | true    | If this is set to false, the cron job that handles profile backups will not be enabled                                                                                                                                                    |
+| `ENABLE_PROFILE_BACKUP`   | true    | If this is set to false, the cron job that handles profile backups will not be enabled. `ENABLE_PROFILE_BACKUPS` (plural) is accepted as an alias                                                                                         |
 | `LISTEN_ALL_NETWORKS`     | false   | If you want to automatically set the SPT server IP addresses to allow it to listen on all network interfaces                                                                                                                              |
 | `TZ`                      | null    | Set the desired time zone. See the `Timezone` section above for details                                                                                                                                                                   |
 | `NUM_HEADLESS_PROFILES`   | null    | Set the desired number of headless profiles for the Fika server to auto-generate. This must be an integer. This will only work if the `fika.jsonc` config file exists, the server automatically generates one on startup if it is missing |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   fika-server:
     image: ghcr.io/zhliau/fika-spt-server-docker:latest
+    restart: unless-stopped
     ports:
       - 6969:6969
     environment:
@@ -15,7 +16,8 @@ services:
       # If you don't want the container to change the file ownership of your server files, set this to false
       - TAKE_OWNERSHIP=true
       # If you don't want to automatically back up profiles, set this to false
-      - ENABLE_PROFILE_BACKUPS=true
+      # Note: the variable name is ENABLE_PROFILE_BACKUP (singular); BACKUPS is accepted as an alias
+      - ENABLE_PROFILE_BACKUP=true
       # If you don't want to automatically change the SPT server IPs to allow it to listen on all interfaces, set this to false.
       - LISTEN_ALL_NETWORKS=true
       # If you want to override the timezone. See https://en.wikipedia.org/wiki/List_of_tz_database_time_zones for a list of valid TZ codes
@@ -24,7 +26,6 @@ services:
       # The version should follow the release archive name format <SPT_VERSION>-<EFT_BUILD_NUMBER>-<SPT_GIT_SHA>
       # user folder backups will be disabled
       # - FORCE_SPT_VERSION=4.0.2-40087-0df4ae7
-    #
 
     volumes:
       # Set this to the directory on your host containing either your existing SPT server files or where you wish to store a new SPT server install

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -74,21 +74,30 @@ fi
 
 take_ownership=${TAKE_OWNERSHIP:-true}
 change_permissions=${CHANGE_PERMISSIONS:-true}
-enable_profile_backup=${ENABLE_PROFILE_BACKUP:-true}
+# Accept common typo ENABLE_PROFILE_BACKUPS as an alias
+enable_profile_backup=${ENABLE_PROFILE_BACKUP:-${ENABLE_PROFILE_BACKUPS:-true}}
 
 num_headless_profiles=${NUM_HEADLESS_PROFILES:+"$NUM_HEADLESS_PROFILES"}
 
 install_other_mods=${INSTALL_OTHER_MODS:-false}
 
+# True when /opt/server is a bind/volume mount (not just the image rootfs).
+is_server_dir_mounted() {
+    local target
+    target=$(findmnt -n -o TARGET --target "$mounted_dir" 2>/dev/null || true)
+    # Unmounted paths resolve to "/"; a real volume/bind shows its own mountpoint.
+    [[ -n "$target" && "$target" != "/" ]]
+}
+
 enforce_spt_4_structure() {
     # detect SPT 4 files in serverfiles root, if exists move everything into SPT/ subdirectory
-    if [[ -f $mounted_dir/$spt_binary ]]; then
+    if [[ -f "$mounted_dir/$spt_binary" ]]; then
         echo "Enforcing SPT 4.0 structure"
-        mkdir -p $spt_dir
-        for item in $mounted_dir/*; do
+        mkdir -p "$spt_dir"
+        for item in "$mounted_dir"/*; do
             base_item=$(basename "$item")
             if [ "$base_item" != "SPT" ]; then
-                mv "$item" $spt_dir
+                mv "$item" "$spt_dir"
             fi
         done
     fi
@@ -103,10 +112,10 @@ start_crond() {
 
 create_running_user() {
     echo "Checking running user/group: $uid:$gid"
-    getent group $gid || groupadd -g $gid spt
-    if [[ ! $(id -un $uid) ]]; then
+    getent group "$gid" >/dev/null || groupadd -g "$gid" spt
+    if ! id -u "$uid" >/dev/null 2>&1; then
         echo "User not found, creating user 'spt' with id $uid"
-        useradd --create-home -u $uid -g $gid spt
+        useradd --create-home -u "$uid" -g "$gid" spt
     fi
 }
 
@@ -123,7 +132,7 @@ validate() {
     fi
 
     # Must mount /opt/server directory, otherwise the serverfiles are in container and there's no persistence
-    if [[ ! $(mount | grep $mounted_dir) ]]; then
+    if ! is_server_dir_mounted; then
         echo "Please mount a volume/directory from the host to $mounted_dir. This server container must store files on the host."
         echo "You can do this with docker run's -v flag e.g. '-v /path/on/host:/opt/server'"
         echo "or with docker-compose's 'volumes' directive"
@@ -134,8 +143,8 @@ validate() {
     # If we have sptVersion in the core config, this means this existing server <= SPT v3
     # If existing SPT major version is less than 4, existing files are not compatible
     echo "Validating SPT version"
-    if [[ -d $nodejs_spt_data_dir && -f $spt_nodejs_core_config ]]; then
-        existing_spt_version=$(jq -r '.sptVersion' $spt_nodejs_core_config)
+    if [[ -d "$nodejs_spt_data_dir" && -f "$spt_nodejs_core_config" ]]; then
+        existing_spt_version=$(jq -r '.sptVersion' "$spt_nodejs_core_config")
         if [[ $existing_spt_version != "null" && $existing_spt_version != "$spt_version" ]]; then
             echo "  ==================="
             echo "  === FATAL ERROR ==="
@@ -152,14 +161,22 @@ validate() {
 
     enforce_spt_4_structure
 
-    if [[ -d $spt_data_dir ]]; then
+    if [[ -d "$spt_data_dir" ]]; then
         # Grab version from binary using exiftool
-        existing_spt_version=$(exiftool -s -s -s -ProductVersion $spt_dir/SPT.Server.dll | cut -d '-' -f 1)
+        if [[ ! -f "$spt_dir/SPT.Server.dll" ]]; then
+            echo "WARNING: SPT.Server.dll not found at $spt_dir/SPT.Server.dll; skipping SPT version validation"
+            existing_spt_version=""
+        else
+            existing_spt_version=$(exiftool -s -s -s -ProductVersion "$spt_dir/SPT.Server.dll" 2>/dev/null | cut -d '-' -f 1 || true)
+            if [[ -z "$existing_spt_version" ]]; then
+                echo "WARNING: Could not read ProductVersion from SPT.Server.dll; skipping SPT version validation"
+            fi
+        fi
         if [[ -n ${force_spt_version} ]]; then
             # Force download SPT archive and install, do not backup or validate
             install_spt
-        elif [[ $existing_spt_version != "$spt_version" ]]; then
-            try_update_spt $existing_spt_version
+        elif [[ -n "$existing_spt_version" && "$existing_spt_version" != "$spt_version" ]]; then
+            try_update_spt "$existing_spt_version"
         fi
 
         # Validate fika version based on FIKA_MODE
@@ -177,7 +194,7 @@ validate() {
                     echo "         Skipping Fika version validation this boot (network/API issue?)."
                 else
                     if [[ -f $fika_mod_dir/FikaServer.dll ]]; then
-                        fika_local_SHA=$(exiftool -s -s -s -ProductVersion $fika_mod_dir/FikaServer.dll | grep -oP '[0-9.]+\+\K.*' || true)
+                        fika_local_SHA=$(exiftool -s -s -s -ProductVersion "$fika_mod_dir/FikaServer.dll" 2>/dev/null | grep -oP '[0-9.]+\+\K.*' || true)
                     fi
                     if [[ "$fika_local_SHA" != "$fika_remote_SHA" ]]; then
                         echo "Fika SHA mismatch: found:$fika_local_SHA != expected:$fika_remote_SHA"
@@ -204,16 +221,21 @@ validate() {
 }
 
 make_and_own_spt_dirs() {
-    mkdir -p $spt_dir/user/mods
-    mkdir -p $spt_dir/user/profiles
+    mkdir -p "$spt_dir/user/mods"
+    mkdir -p "$spt_dir/user/profiles"
     change_owner
     set_permissions
 }
 
 change_owner() {
     if [[ "$take_ownership" == "true" ]]; then
+        # Skip full recursive chown when everything is already owned correctly
+        if ! find "$mounted_dir" -xdev \( ! -user "$uid" -o ! -group "$gid" \) -print -quit 2>/dev/null | grep -q .; then
+            echo "Ownership already ${uid}:${gid}, skipping chown"
+            return 0
+        fi
         echo "Changing owner of serverfiles to $uid:$gid"
-        chown -R ${uid}:${gid} $mounted_dir
+        chown -R "${uid}:${gid}" "$mounted_dir"
     fi
 }
 
@@ -222,7 +244,7 @@ set_permissions() {
         echo "Changing permissions of server files to user+rwx, group+rwx, others+rx"
         # owner(u), (g)roup, (o)ther
         # (r)ead, (w)rite, e(x)ecute
-        chmod -R u+rwx,g+rwx,o+rx $mounted_dir
+        chmod -R u+rwx,g+rwx,o+rx "$mounted_dir"
     fi
 }
 
@@ -230,7 +252,7 @@ set_timezone() {
     # If the TZ environment variable has been set, use it
     if [[ ! -z "${TZ}" ]]; then
         # Update the /etc/timezone to the specified time zone
-        echo $TZ > /etc/timezone
+        echo "$TZ" > /etc/timezone
     else
         # Grab the hour from the date command to compare against later
         before_date_hour=$(date +"%H")
@@ -240,7 +262,7 @@ set_timezone() {
     fi
 
     # Force update the symlink
-    ln -sf /usr/share/zoneinfo/$TZ /etc/localtime
+    ln -sf "/usr/share/zoneinfo/$TZ" /etc/localtime
 
     # If there was actually a change in the timezone or TZ was specified (accounted for here when before_date_hour is not set above)
     if [[ $before_date_hour != $(date +"%H") ]]; then
@@ -254,38 +276,55 @@ set_timezone() {
 install_fika_mod() {
     echo "Installing Fika servermod version $fika_version"
     # Assumes fika_server.zip artifact contains user/mods/fika-server
-    curl -sL $fika_release_url -O
-    unzip -q $fika_artifact -d $mounted_dir/temp_fika/
-    mv $mounted_dir/temp_fika/SPT/user/mods/fika-server $spt_dir/user/mods/
-    rm -r $mounted_dir/temp_fika
-    rm $fika_artifact
+    local tmpzip="/tmp/$fika_artifact"
+    if ! curl -fSL --connect-timeout 10 --max-time 300 "$fika_release_url" -o "$tmpzip"; then
+        echo "ERROR: Failed to download Fika from $fika_release_url"
+        exit 1
+    fi
+    rm -rf "$mounted_dir/temp_fika"
+    mkdir -p "$mounted_dir/temp_fika"
+    if ! unzip -q "$tmpzip" -d "$mounted_dir/temp_fika/"; then
+        echo "ERROR: Failed to extract Fika archive $fika_artifact"
+        rm -f "$tmpzip"
+        rm -rf "$mounted_dir/temp_fika"
+        exit 1
+    fi
+    if [[ ! -d "$mounted_dir/temp_fika/SPT/user/mods/fika-server" ]]; then
+        echo "ERROR: Fika archive did not contain SPT/user/mods/fika-server"
+        rm -f "$tmpzip"
+        rm -rf "$mounted_dir/temp_fika"
+        exit 1
+    fi
+    mv "$mounted_dir/temp_fika/SPT/user/mods/fika-server" "$spt_dir/user/mods/"
+    rm -rf "$mounted_dir/temp_fika"
+    rm -f "$tmpzip"
     echo "Installation complete"
 }
 
 backup_fika() {
-    mkdir -p $fika_backup_dir
-    cp -r $fika_mod_dir $fika_backup_dir
+    mkdir -p "$fika_backup_dir"
+    cp -r "$fika_mod_dir" "$fika_backup_dir"
 }
 
 try_update_fika() {
     echo "Updating Fika servermod in place to $fika_version"
     # Backup entire fika servermod, then delete and update servermod
     backup_fika
-    rm -r $fika_mod_dir
+    rm -r "$fika_mod_dir"
     install_fika_mod
     # restore config
-    mkdir -p $fika_mod_dir/assets/configs
-    existing_fika_config=$fika_backup_dir/fika-server/$fika_config_path
-    if [[ -f $existing_fika_config ]]; then
-        cp $existing_fika_config $fika_mod_dir/$fika_config_path
+    mkdir -p "$fika_mod_dir/assets/configs"
+    existing_fika_config="$fika_backup_dir/fika-server/$fika_config_path"
+    if [[ -f "$existing_fika_config" ]]; then
+        cp "$existing_fika_config" "$fika_mod_dir/$fika_config_path"
     fi
     echo "Successfully updated Fika to $fika_version"
 }
 
 set_num_headless_profiles() {
-    if [[ ${num_headless_profiles:+1} && -f $fika_mod_dir/$fika_config_path ]]; then
+    if [[ ${num_headless_profiles:+1} && -f "$fika_mod_dir/$fika_config_path" ]]; then
         echo "Setting number of headless profiles to $num_headless_profiles"
-        modified_fika_jsonc="$(jq --arg jq_num_headless_profiles $num_headless_profiles '.headless.profiles.amount=($jq_num_headless_profiles | tonumber)' $fika_mod_dir/$fika_config_path)" && echo -E "${modified_fika_jsonc}" > $fika_mod_dir/$fika_config_path
+        modified_fika_jsonc="$(jq --arg jq_num_headless_profiles "$num_headless_profiles" '.headless.profiles.amount=($jq_num_headless_profiles | tonumber)' "$fika_mod_dir/$fika_config_path")" && echo -E "${modified_fika_jsonc}" > "$fika_mod_dir/$fika_config_path"
     fi
 }
 
@@ -300,30 +339,39 @@ install_spt() {
         echo "!! Forcing SPT version to $force_spt_version     !!"
         echo "!! SPT auto-update is disabled                    !!"
         echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-        cd ${mounted_dir}
+        cd "${mounted_dir}"
         # check if archive already exists, and extract if so
         if [[ ! -f ${forced_spt_version_archive} ]]; then
             echo "Downloading https://spt-releases.modd.in/SPT-${force_spt_version}.7z"
-            curl -sL "https://spt-releases.modd.in/SPT-${force_spt_version}.7z" -o ${forced_spt_version_archive}
+            if ! curl -fSL --connect-timeout 10 --max-time 600 \
+                "https://spt-releases.modd.in/SPT-${force_spt_version}.7z" \
+                -o "${forced_spt_version_archive}"; then
+                echo "ERROR: Failed to download SPT-${force_spt_version}.7z"
+                rm -f "${forced_spt_version_archive}"
+                exit 1
+            fi
             # Remove the server files, since databases tend to be different between versions
-            rm -rf $spt_data_dir
-            7zz x ${forced_spt_version_archive} -aoa
+            rm -rf "$spt_data_dir"
+            if ! 7zz x "${forced_spt_version_archive}" -aoa; then
+                echo "ERROR: Failed to extract ${forced_spt_version_archive}"
+                exit 1
+            fi
         else
             echo "Version already downloaded and presumed installed. Skipping SPT installation."
             echo "If you want to force reinstall this server version ${force_spt_version}, remove the SPT-*.7z archive in your mounted server files directory."
         fi
     else
         # Remove the server files, since databases tend to be different between versions
-        rm -rf $spt_data_dir
-        cp -r $build_dir/* $mounted_dir
+        rm -rf "$spt_data_dir"
+        cp -r "$build_dir"/* "$mounted_dir"
     fi
     make_and_own_spt_dirs
 }
 
 # TODO Anticipate BepInEx too, for Corter-ModSync
 backup_spt_user_dirs() {
-    mkdir -p $spt_backup_dir
-    cp -r $spt_dir/user $spt_backup_dir/
+    mkdir -p "$spt_backup_dir"
+    cp -r "$spt_dir/user" "$spt_backup_dir/"
 }
 
 try_update_spt() {
@@ -345,7 +393,7 @@ try_update_spt() {
     echo ""
     echo "  The user/ folder has been backed up to $spt_backup_dir, but otherwise has been LEFT UNTOUCHED in the server dir."
     echo "  Please verify your existing mods and profile work with this new SPT version! You may want to delete the mods directory and start from scratch"
-    echo "  Restart this container to bring the server back up"
+    echo "  Exiting so Docker can restart the container (use restart: unless-stopped) or start it again manually to bring the server back up."
     echo ""
     echo "  ==============="
     exit 0
@@ -354,11 +402,11 @@ try_update_spt() {
 spt_listen_on_all_networks() {
     # Changes the ip and backendIp to 0.0.0.0 so that the server will listen on all network interfaces.
     http_json=$spt_data_dir/configs/http.json
-    modified_http_json="$(jq '.ip = "0.0.0.0" | .backendIp = "0.0.0.0"' $http_json)" && echo -E "${modified_http_json}" > $http_json
+    modified_http_json="$(jq '.ip = "0.0.0.0" | .backendIp = "0.0.0.0"' "$http_json")" && echo -E "${modified_http_json}" > "$http_json"
     # If fika server config exists, modify that too
     if [[ -f "$fika_mod_dir/$fika_config_path" ]]; then
         echo "Setting listen all networks in Fika SPT config override"
-        modified_fika_jsonc="$(jq '.server.SPT.http.ip = "0.0.0.0" | .server.SPT.http.backendIp = "0.0.0.0"' $fika_mod_dir/$fika_config_path)" && echo -E "${modified_fika_jsonc}" > $fika_mod_dir/$fika_config_path
+        modified_fika_jsonc="$(jq '.server.SPT.http.ip = "0.0.0.0" | .server.SPT.http.backendIp = "0.0.0.0"' "$fika_mod_dir/$fika_config_path")" && echo -E "${modified_fika_jsonc}" > "$fika_mod_dir/$fika_config_path"
     fi
 }
 
@@ -369,7 +417,7 @@ spt_listen_on_all_networks() {
 install_requested_mods() {
     # Run the download & install mods script
     echo "Downloading and installing other mods"
-    /usr/bin/download_unzip_install_mods $spt_dir
+    /usr/bin/download_unzip_install_mods "$spt_dir"
 }
 
 ##############
@@ -436,4 +484,4 @@ set_permissions
 
 set_timezone
 
-su - $(id -nu $uid) -c "cd $spt_dir && ./$spt_binary"
+su - "$(id -nu "$uid")" -c "cd \"$spt_dir\" && ./$spt_binary"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,9 +30,23 @@ fika_config_path=assets/configs/fika.jsonc
 fika_mod_dir=$spt_dir/user/mods/fika-server
 fika_artifact=Fika.Server.Release.$fika_version.zip
 fika_release_url="https://github.com/project-fika/Fika-Server-CSharp/releases/download/v$fika_version/$fika_artifact"
-fika_remote_SHA=$(curl -s "https://api.github.com/repos/project-fika/Fika-Server-CSharp/git/refs/tags/v$fika_version" | grep -oP '"sha":\s*"\K[^"]+')
+# Fetched lazily in validate() only when FIKA_MODE needs it. Do not curl at
+# top-level under bash -e: a missing "sha" (rate limit, network blip, bad JSON)
+# makes grep fail and aborts the entrypoint with exit 1 and no logs.
+fika_remote_SHA=
 
 auto_update_spt=${AUTO_UPDATE_SPT:-false}
+
+# Resolve the Fika release tag SHA from GitHub. Returns empty on failure and
+# never trips bash -e, so FIKA_MODE=disabled boots without requiring GitHub.
+fetch_fika_remote_sha() {
+    local response sha
+    response=$(curl -fsS --connect-timeout 10 --max-time 30 \
+        "https://api.github.com/repos/project-fika/Fika-Server-CSharp/git/refs/tags/v$fika_version" \
+        2>/dev/null || true)
+    sha=$(printf '%s' "$response" | grep -oP '"sha":\s*"\K[^"]+' || true)
+    printf '%s' "$sha"
+}
 
 # Backwards compatibility for deprecated variables
 install_fika=${INSTALL_FIKA:-}
@@ -157,18 +171,24 @@ validate() {
                 echo "Skipping Fika validation (FIKA_MODE=custom)"
                 ;;
             install|auto-update)
-                if [[ -f $fika_mod_dir/FikaServer.dll ]]; then
-                    fika_local_SHA=$(exiftool -s -s -s -ProductVersion $fika_mod_dir/FikaServer.dll | grep -oP '[0-9.]+\+\K.*')
-                fi
-                if [[ "$fika_local_SHA" != "$fika_remote_SHA" ]]; then
-                    echo "Fika SHA mismatch: found:$fika_local_SHA != expected:$fika_remote_SHA"
-                    if [[ "$fika_mode" == "auto-update" ]]; then
-                        echo "Auto-updating Fika version to $fika_version"
-                        try_update_fika
-                    else
-                        echo "Fika version mismatch detected. Set FIKA_MODE=auto-update to enable automatic updates."
-                        echo "Aborting"
-                        exit 1
+                fika_remote_SHA=$(fetch_fika_remote_sha)
+                if [[ -z "$fika_remote_SHA" ]]; then
+                    echo "WARNING: Could not resolve Fika release SHA for v$fika_version from GitHub."
+                    echo "         Skipping Fika version validation this boot (network/API issue?)."
+                else
+                    if [[ -f $fika_mod_dir/FikaServer.dll ]]; then
+                        fika_local_SHA=$(exiftool -s -s -s -ProductVersion $fika_mod_dir/FikaServer.dll | grep -oP '[0-9.]+\+\K.*' || true)
+                    fi
+                    if [[ "$fika_local_SHA" != "$fika_remote_SHA" ]]; then
+                        echo "Fika SHA mismatch: found:$fika_local_SHA != expected:$fika_remote_SHA"
+                        if [[ "$fika_mode" == "auto-update" ]]; then
+                            echo "Auto-updating Fika version to $fika_version"
+                            try_update_fika
+                        else
+                            echo "Fika version mismatch detected. Set FIKA_MODE=auto-update to enable automatic updates."
+                            echo "Aborting"
+                            exit 1
+                        fi
                     fi
                 fi
                 ;;

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,17 +1,34 @@
 #!/bin/bash -e
 
 mounted_dir=/opt/server
-profiles_dir=$mounted_dir/user/profiles
+# SPT 4 layout stores profiles under SPT/user/profiles
+profiles_dir=$mounted_dir/SPT/user/profiles
+# Legacy SPT 3 path fallback
+legacy_profiles_dir=$mounted_dir/user/profiles
 timestamp=$(date +%Y%m%dT%H%M)
 backup_dir=$mounted_dir/backups/profiles/$timestamp
 
-if [[ ! $(mount | grep $mounted_dir) ]]; then
+is_server_dir_mounted() {
+    local target
+    target=$(findmnt -n -o TARGET --target "$mounted_dir" 2>/dev/null || true)
+    [[ -n "$target" && "$target" != "/" ]]
+}
+
+if ! is_server_dir_mounted; then
     echo "Failed to run profile backup! Server directory not mounted!" >> /proc/1/fd/1
     exit 1
 fi
 
-echo "Backing up profiles. Destination is $backup_dir" >> /proc/1/fd/1
-mkdir -p $backup_dir
-# Backup profiles
-cp -r $profiles_dir $backup_dir
+if [[ -d "$profiles_dir" ]]; then
+    source_profiles="$profiles_dir"
+elif [[ -d "$legacy_profiles_dir" ]]; then
+    source_profiles="$legacy_profiles_dir"
+else
+    echo "Failed to run profile backup! Profiles directory not found at $profiles_dir" >> /proc/1/fd/1
+    exit 1
+fi
+
+echo "Backing up profiles from $source_profiles. Destination is $backup_dir" >> /proc/1/fd/1
+mkdir -p "$backup_dir"
+cp -r "$source_profiles" "$backup_dir"
 echo "Backup complete." >> /proc/1/fd/1

--- a/scripts/download_unzip_install_mods.sh
+++ b/scripts/download_unzip_install_mods.sh
@@ -114,14 +114,17 @@ download_new_urls() {
         mkdir -p $tmp_downloaded_dir
         echo "  Finished compiling url download list. Starting downloads" | tee -a $download_unzip_install_logs_filepath
 
-        aria2c -q --content-disposition-default-utf8 true \
+        if aria2c -q --content-disposition-default-utf8 true \
         --input-file=$new_urls_to_download_filepath \
         --dir=$tmp_downloaded_dir \
         --log-level=notice \
-        --log=$download_unzip_install_logs_filepath
-
-        # Once all downloads are complete, append the downloaded files list to the master list for .
-        cat $new_urls_to_download_filepath >> $mod_urls_downloaded_filepath
+        --log=$download_unzip_install_logs_filepath; then
+            # Only mark URLs as downloaded after aria2 succeeds
+            cat $new_urls_to_download_filepath >> $mod_urls_downloaded_filepath
+        else
+            echo "  ERROR: One or more mod downloads failed. URLs were NOT marked as downloaded." | tee -a $download_unzip_install_logs_filepath
+            return 1
+        fi
     else
         # Local variable to send the same message to stdout with a double space indentation and to the logs without
         local message="No new urls. Nothing to download"


### PR DESCRIPTION
## Summary
- Harden `entrypoint.sh`: safe Fika SHA lookup (already included), `curl -fSL` downloads with extract checks, `findmnt`-based mount detection, safer SPT version probing, skip redundant `chown`, accept `ENABLE_PROFILE_BACKUPS` alias
- Fix `backup.sh` for SPT 4 profile path (`SPT/user/profiles`) with legacy fallback
- Only mark mod URLs as downloaded after aria2 succeeds
- Add `HEALTHCHECK`, drop unused `vim`, set `restart: unless-stopped` in example compose

Supersedes #86 (same SHA-lookup fix plus the hardening above).

## Test plan
- [ ] Fresh empty volume mount boots and installs SPT
- [ ] Existing SPT 4 install with `FIKA_MODE=disabled` boots even if GitHub API is unreachable
- [ ] Failed Fika/SPT download prints an error and exits non-zero (no empty unzip)
- [ ] Profile cron backup writes under `backups/profiles/` from `SPT/user/profiles`
- [ ] Compose `restart: unless-stopped` brings the container back after host reboot
- [ ] Healthcheck reports healthy after server is listening on `:6969`